### PR TITLE
fix `map_ggplot()`: return map object `m`

### DIFF
--- a/R/map.R
+++ b/R/map.R
@@ -63,4 +63,5 @@ map_ggplot <- function(data, color = "#ff3399") {
     xlab("longitude") +
     ylab("latitude") +
     coord_quickmap()
+  m
 }


### PR DESCRIPTION
Hi @pieterprovoost,

Just noticing the tiniest bug in `map_ggplot()`, which creates the ggplot `m` object but neglects to return it in the function, so you get nothing when running it. This pr simply adds the `m` to the end of the function to return the ggplot2 map object.
